### PR TITLE
orch via systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ source venv/bin/activate # Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+## Deploy server
+
+Must be done by a user with sudo privileges (ensure to change user in the `cartel.service` file)
+
+```bash
+sudo cp cartel.service /etc/systemd/system/cartel.service
+sudo systemctl daemon-reload
+sudo systemctl enable cartel.service # Start on boot
+sudo systemctl start cartel.service # Start now
+```
+
 ## Usage
 
 ```bash

--- a/cartel.service
+++ b/cartel.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cartel Server
+
+[Service]
+ExecStart=python3 /var/www/html/cartel/cartel.py
+WorkingDirectory=/var/www/html/cartel
+User=mark
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Use `.service` file to orchestrate cartel server as a system service
- Start on boot, retry 3x on fail
- Waits for network